### PR TITLE
Portfolio: preserve data in the browser for code review.

### DIFF
--- a/index.html
+++ b/index.html
@@ -258,5 +258,6 @@
         <script src="js/mobileMenu.js"></script>
         <script src="js/modalPopup.js"></script>
         <script src="js/formValidation.js"></script>
+        <script src="js/localStorage.js"></script>
     </body>
 </html>

--- a/js/localStorage.js
+++ b/js/localStorage.js
@@ -1,54 +1,54 @@
 const formDataContent = {
-    available: null,
-    formName: document.getElementById('name'),
-    formEmail: document.getElementById('email'),
-    formMessage: document.getElementById('message'),
-    userData: {
-        name: null,
-        email: null,
-        message: null,
-      },
-    storedJson: null,
-    storedObject: null,
-    toStore: null,
-  };
+  available: null,
+  formName: document.getElementById('name'),
+  formEmail: document.getElementById('email'),
+  formMessage: document.getElementById('message'),
+  userData: {
+    name: null,
+    email: null,
+    message: null,
+  },
+  storedJson: null,
+  storedObject: null,
+  toStore: null,
+};
 
-  if (window.localStorage) {
-    formDataContent.available = true;
-  }
+if (window.localStorage) {
+  formDataContent.available = true;
+}
 
-  const retrieveStorage = {
-    dataRetrieve() {
-        formDataContent.storedJson = localStorage.getItem('jsonObj');
-        formDataContent.storedObject = JSON.parse(formDataContent.storedJson);
-    },
+const retrieveStorage = {
+  dataRetrieve() {
+    formDataContent.storedJson = localStorage.getItem('jsonObj');
+    formDataContent.storedObject = JSON.parse(formDataContent.storedJson);
+  },
 
-    attributes() {
-        formDataContent.formName.setAttribute('value', formDataContent.storedObject.formName);
-        formDataContent.formEmail.setAttribute('value', formData.storedObject.formEmail);
-        formDataContent.formMessage.setAttribute('value', formData.storedObject.formMessage);
-    },
+  attributes() {
+    formDataContent.formName.setAttribute('value', formDataContent.storedObject.formName);
+    formDataContent.formEmail.setAttribute('value', formDataContent.storedObject.formEmail);
+    formDataContent.formMessage.setAttribute('value', formDataContent.storedObject.formMessage);
+  },
 
-    addEvents() {
-        if (formDataContent.available === true) {
-            formDataContent.formName.addEventListener('change', retrieveStorage.store);
-            formDataContent.formEmail.addEventListener('change', retrieveStorage.store);
-            formDataContent.formMessage.addEventListener('change', retrieveStorage.store);
-        }
-    },
+  addEvents() {
+    if (formDataContent.available === true) {
+      formDataContent.formName.addEventListener('change', retrieveStorage.store);
+      formDataContent.formEmail.addEventListener('change', retrieveStorage.store);
+      formDataContent.formMessage.addEventListener('change', retrieveStorage.store);
+    }
+  },
 
-    storeData() {
-        formDataContent.userData.name = formDataContent.formName.value;
-        formDataContent.userData.email = formDataContent.formEmail.value;
-        formDataContent.userData.message = formDataContent.formMessage.value;
+  storeData() {
+    formDataContent.userData.name = formDataContent.formName.value;
+    formDataContent.userData.email = formDataContent.formEmail.value;
+    formDataContent.userData.message = formDataContent.formMessage.value;
 
-        formDataContent.toStore = JSON.stringify(formDataContent.userData);
-        if (formDataContent.storedJson !== formDataContent.toStore) {
-            window.localStorage.setItem('jsonObj', formDataContent.toStore);
-        }
-    },
-  };
+    formDataContent.toStore = JSON.stringify(formDataContent.userData);
+    if (formDataContent.storedJson !== formDataContent.toStore) {
+      window.localStorage.setItem('jsonObj', formDataContent.toStore);
+    }
+  },
+};
 
-  retrieveStorage.dataRetrieve();
-  retrieveStorage.attributes();
-  retrieveStorage.addEvents();
+retrieveStorage.dataRetrieve();
+retrieveStorage.attributes();
+retrieveStorage.addEvents();

--- a/js/localStorage.js
+++ b/js/localStorage.js
@@ -1,54 +1,35 @@
-const formDataContent = {
-  available: null,
-  name: document.getElementById('name'),
-  email: document.getElementById('email'),
-  message: document.getElementById('message'),
-  userData: {
-    name: null,
-    email: null,
-    message: null,
-  },
-  storedJson: null,
-  storedObject: null,
-  toStore: null,
+const name = document.getElementById('name');
+const email = document.getElementById('email');
+const message = document.getElementById('message');
+
+let formData = {
+  name: '',
+  email: '',
+  message: '',
 };
 
-if (window.localStorage) {
-  formDataContent.available = true;
-}
-
-const retrieveStorage = {
-  dataRetrieve() {
-    formDataContent.storedJson = localStorage.getItem('jsonObj');
-    formDataContent.storedObject = JSON.parse(formDataContent.storedJson);
-  },
-
-  attributes() {
-    formDataContent.name.setAttribute('value', formDataContent.storedObject.name);
-    formDataContent.email.setAttribute('value', formDataContent.storedObject.email);
-    formDataContent.message.setAttribute('value', formDataContent.storedObject.message);
-  },
-
-  addEvents() {
-    if (formDataContent.available === true) {
-      formDataContent.name.addEventListener('change', retrieveStorage.store);
-      formDataContent.email.addEventListener('change', retrieveStorage.store);
-      formDataContent.message.addEventListener('change', retrieveStorage.store);
-    }
-  },
-
-  storeData() {
-    formDataContent.userData.name = formDataContent.name.value;
-    formDataContent.userData.email = formDataContent.email.value;
-    formDataContent.userData.message = formDataContent.message.value;
-
-    formDataContent.toStore = JSON.stringify(formDataContent.userData);
-    if (formDataContent.storedJson !== formDataContent.toStore) {
-      window.localStorage.setItem('jsonObj', formDataContent.toStore);
-    }
-  },
+const saveToLocalStorage = () => {
+  localStorage.setItem('form_data', JSON.stringify(formData));
 };
 
-retrieveStorage.dataRetrieve();
-retrieveStorage.attributes();
-retrieveStorage.addEvents();
+name.addEventListener('change', () => {
+  formData.name = name.value;
+  saveToLocalStorage();
+});
+email.addEventListener('change', () => {
+  formData.email = email.value;
+  saveToLocalStorage();
+});
+message.addEventListener('change', () => {
+  formData.message = message.value;
+  saveToLocalStorage();
+});
+
+window.onload = () => {
+  if (localStorage.getItem('form_data') !== null) {
+    formData = JSON.parse(localStorage.getItem('form_data'));
+    name.value = formData.name;
+    email.value = formData.email;
+    message.value = formData.message;
+  }
+};

--- a/js/localStorage.js
+++ b/js/localStorage.js
@@ -1,0 +1,54 @@
+const formDataContent = {
+    available: null,
+    formName: document.getElementById('name'),
+    formEmail: document.getElementById('email'),
+    formMessage: document.getElementById('message'),
+    userData: {
+        name: null,
+        email: null,
+        message: null,
+      },
+    storedJson: null,
+    storedObject: null,
+    toStore: null,
+  };
+
+  if (window.localStorage) {
+    formDataContent.available = true;
+  }
+
+  const retrieveStorage = {
+    dataRetrieve() {
+        formDataContent.storedJson = localStorage.getItem('jsonObj');
+        formDataContent.storedObject = JSON.parse(formDataContent.storedJson);
+    },
+
+    attributes() {
+        formDataContent.formName.setAttribute('value', formDataContent.storedObject.formName);
+        formDataContent.formEmail.setAttribute('value', formData.storedObject.formEmail);
+        formDataContent.formMessage.setAttribute('value', formData.storedObject.formMessage);
+    },
+
+    addEvents() {
+        if (formDataContent.available === true) {
+            formDataContent.formName.addEventListener('change', retrieveStorage.store);
+            formDataContent.formEmail.addEventListener('change', retrieveStorage.store);
+            formDataContent.formMessage.addEventListener('change', retrieveStorage.store);
+        }
+    },
+
+    storeData() {
+        formDataContent.userData.name = formDataContent.formName.value;
+        formDataContent.userData.email = formDataContent.formEmail.value;
+        formDataContent.userData.message = formDataContent.formMessage.value;
+
+        formDataContent.toStore = JSON.stringify(formDataContent.userData);
+        if (formDataContent.storedJson !== formDataContent.toStore) {
+            window.localStorage.setItem('jsonObj', formDataContent.toStore);
+        }
+    },
+  };
+
+  retrieveStorage.dataRetrieve();
+  retrieveStorage.attributes();
+  retrieveStorage.addEvents();

--- a/js/localStorage.js
+++ b/js/localStorage.js
@@ -1,8 +1,8 @@
 const formDataContent = {
   available: null,
-  formName: document.getElementById('name'),
-  formEmail: document.getElementById('email'),
-  formMessage: document.getElementById('message'),
+  name: document.getElementById('name'),
+  email: document.getElementById('email'),
+  message: document.getElementById('message'),
   userData: {
     name: null,
     email: null,
@@ -24,23 +24,23 @@ const retrieveStorage = {
   },
 
   attributes() {
-    formDataContent.formName.setAttribute('value', formDataContent.storedObject.formName);
-    formDataContent.formEmail.setAttribute('value', formDataContent.storedObject.formEmail);
-    formDataContent.formMessage.setAttribute('value', formDataContent.storedObject.formMessage);
+    formDataContent.name.setAttribute('value', formDataContent.storedObject.name);
+    formDataContent.email.setAttribute('value', formDataContent.storedObject.email);
+    formDataContent.message.setAttribute('value', formDataContent.storedObject.message);
   },
 
   addEvents() {
     if (formDataContent.available === true) {
-      formDataContent.formName.addEventListener('change', retrieveStorage.store);
-      formDataContent.formEmail.addEventListener('change', retrieveStorage.store);
-      formDataContent.formMessage.addEventListener('change', retrieveStorage.store);
+      formDataContent.name.addEventListener('change', retrieveStorage.store);
+      formDataContent.email.addEventListener('change', retrieveStorage.store);
+      formDataContent.message.addEventListener('change', retrieveStorage.store);
     }
   },
 
   storeData() {
-    formDataContent.userData.name = formDataContent.formName.value;
-    formDataContent.userData.email = formDataContent.formEmail.value;
-    formDataContent.userData.message = formDataContent.formMessage.value;
+    formDataContent.userData.name = formDataContent.name.value;
+    formDataContent.userData.email = formDataContent.email.value;
+    formDataContent.userData.message = formDataContent.message.value;
 
     formDataContent.toStore = JSON.stringify(formDataContent.userData);
     if (formDataContent.storedJson !== formDataContent.toStore) {


### PR DESCRIPTION
# In the final milestone of my portfolio site, I;
- created a single JavaScript object with all the data from the entire form and save it in local storage.
- I made sure that when the user changes the content of any input field, the data is saved to the local storage.
- I also made sure that when the user loads the page, if there is any data in the local storage the input fields are pre-filled with this data.